### PR TITLE
onIdle should returns ID value

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,14 @@ Safely detect when the browser is idle. Does nothing when run in Node.
 var onIdle = require('on-idle')
 var html = require('bel')
 
-onIdle(function () {
+var cancel = onIdle(function () {
   var el = html`<h1>browser is idle</h1>`
   document.body.appendChild(el)
 })
+
+if (somethingHappens) {
+  cancel()
+}
 ```
 
 ## API

--- a/example.js
+++ b/example.js
@@ -10,3 +10,9 @@ onIdle(function () {
 onIdle(function () {
   console.log('fast message')
 })
+
+var cancel = onIdle(function () {
+  console.log('this callback will be cancelled')
+})
+
+cancel()

--- a/index.js
+++ b/index.js
@@ -8,13 +8,16 @@ module.exports = onIdle
 
 function onIdle (cb, opts) {
   opts = opts || dftOpts
+  var timerId
 
   assert.equal(typeof cb, 'function', 'on-idle: cb should be type function')
   assert.equal(typeof opts, 'object', 'on-idle: opts should be type object')
 
   if (hasIdle) {
-    window.requestIdleCallback(cb, opts)
+    timerId = window.requestIdleCallback(cb, opts)
+    return window.cancelIdleCallback.bind(window, timerId)
   } else if (hasWindow) {
-    setTimeout(cb, 0)
+    timerId = setTimeout(cb, 0)
+    return clearTimeout.bind(window, timerId)
   }
 }


### PR DESCRIPTION
Sometimes we want to cancel.:)

```js
var timerId = onIdle(next)
window.cancelIdleCallback(timerId)
// or clearTimeout(timerId)
```

or we just need an alias for `cancelIdleCallback or cleartimeout`?