### PR TITLE
Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ Call a function when the browser has spare time. Calls it on the next frame if
 [1]: https://nodejs.org/api/documentation.html#documentation_stability_index
 [2]: https://img.shields.io/npm/v/on-idle.svg?style=flat-square
 [3]: https://npmjs.org/package/on-idle
-[4]: https://img.shields.io/travis/yoshuawuyts/on-idle/master.svg?style=flat-square
-[5]: https://travis-ci.org/yoshuawuyts/on-idle
-[6]: https://img.shields.io/codecov/c/github/yoshuawuyts/on-idle/master.svg?style=flat-square
-[7]: https://codecov.io/github/yoshuawuyts/on-idle
+[4]: https://img.shields.io/travis/choojs/on-idle/master.svg?style=flat-square
+[5]: https://travis-ci.org/choojs/on-idle
+[6]: https://img.shields.io/codecov/c/github/choojs/on-idle/master.svg?style=flat-square
+[7]: https://codecov.io/github/choojs/on-idle
 [8]: http://img.shields.io/npm/dm/on-idle.svg?style=flat-square
 [9]: https://npmjs.org/package/on-idle
 [10]: https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat-square

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "on-idle",
   "description": "Detect when the browser is idle",
-  "repository": "yoshuawuyts/on-idle",
+  "repository": "choojs/on-idle",
   "version": "3.1.2",
   "scripts": {
     "deps": "dependency-check . && dependency-check . --extra --no-dev",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,12 @@
     "test": "standard && npm run deps",
     "coverage": "nyc report --reporter=text-lcov > coverage.lcov"
   },
-  "dependencies": {},
+  "browser": {
+    "assert": "nanoassert"
+  },
+  "dependencies": {
+    "nanoassert": "^1.1.0"
+  },
   "devDependencies": {
     "bankai": "^7.6.2",
     "dependency-check": "^2.8.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "repository": "choojs/on-idle",
   "version": "3.1.2",
   "scripts": {
-    "deps": "dependency-check . && dependency-check . --extra --no-dev",
+    "deps": "dependency-check . && dependency-check . --extra --no-dev -i nanoassert",
     "start": "bankai start example.js",
     "test": "standard && npm run deps",
     "coverage": "nyc report --reporter=text-lcov > coverage.lcov"


### PR DESCRIPTION
- creates performance entries for idle timings
- fixes references in docs & package.json to choojs org
- adds `nanoassert` as a dep to be used in browsers instead of assert